### PR TITLE
Scope creates, updates, and deletes to the current scope

### DIFF
--- a/lib/graphiti/adapters/abstract.rb
+++ b/lib/graphiti/adapters/abstract.rb
@@ -381,7 +381,7 @@ module Graphiti
         raise "you must override #disassociate in an adapter subclass"
       end
 
-      def build(model_class)
+      def build(model_class, scope)
         model_class.new
       end
 

--- a/lib/graphiti/adapters/active_record.rb
+++ b/lib/graphiti/adapters/active_record.rb
@@ -273,18 +273,8 @@ module Graphiti
         # Nothing to do in the else case, happened when we merged foreign key
       end
 
-      # (see Adapters::Abstract#create)
-      def create(model_class, create_params)
-        instance = model_class.new(create_params)
-        instance.save
-        instance
-      end
-
-      # (see Adapters::Abstract#update)
-      def update(model_class, update_params)
-        instance = model_class.find(update_params.only(:id))
-        instance.update_attributes(update_params.except(:id))
-        instance
+      def build(model_class, scope)
+        scope.build
       end
 
       def save(model_instance)

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -96,9 +96,9 @@ module Graphiti
       adapter.disassociate(parent, child, association_name, type)
     end
 
-    def persist_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil)
+    def persist_with_relationships(meta, attributes, relationships, caller_model = nil, foreign_key = nil, scope = nil)
       persistence = Graphiti::Util::Persistence \
-        .new(self, meta, attributes, relationships, caller_model, foreign_key)
+        .new(self, meta, attributes, relationships, caller_model, foreign_key, scope)
       persistence.run
     end
 

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -98,7 +98,10 @@ module Graphiti
           @resource.persist_with_relationships \
             @payload.meta(action: action),
             @payload.attributes,
-            @payload.relationships
+            @payload.relationships,
+            nil,
+            nil,
+            @scope
         }
       ensure
         Graphiti.context[:namespace] = original
@@ -119,7 +122,7 @@ module Graphiti
 
     def destroy
       transaction_response = @resource.transaction do
-        metadata = {method: :destroy}
+        metadata = {method: :destroy, scope: @scope}
         model = @resource.destroy(@query.filters[:id], metadata)
         model.instance_variable_set(:@__serializer_klass, @resource.serializer)
         @resource.after_graph_persist(model, metadata)

--- a/lib/graphiti/util/persistence.rb
+++ b/lib/graphiti/util/persistence.rb
@@ -7,13 +7,14 @@ class Graphiti::Util::Persistence
   # @param [Hash] relationships see (Deserializer#relationships)
   # @param [Model] caller_model The persisted parent object in the request graph
   # @param [Symbol] foreign_key Attribute assigned by parent object in graph
-  def initialize(resource, meta, attributes, relationships, caller_model, foreign_key = nil)
+  def initialize(resource, meta, attributes, relationships, caller_model, foreign_key = nil, scope = nil)
     @resource = resource
     @meta = meta
     @attributes = attributes
     @relationships = relationships
     @caller_model = caller_model
     @foreign_key = foreign_key
+    @scope = scope
 
     # Find the correct child resource for a given jsonapi type
     if (meta_type = @meta[:type].try(:to_sym))
@@ -222,7 +223,8 @@ class Graphiti::Util::Persistence
       temp_id: @meta[:temp_id],
       caller_model: @caller_model,
       attributes: @attributes,
-      relationships: @relationships
+      relationships: @relationships,
+      scope: @scope
     }
   end
 

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -1529,7 +1529,7 @@ RSpec.describe "persistence" do
         it "works" do
           employee = PORO::Employee.create(first_name: "Jane")
           klass.find(id: employee.id).destroy
-          expect(klass.meta).to eq(method: :destroy)
+          expect(klass.meta).to include(method: :destroy)
         end
       end
 
@@ -1547,7 +1547,7 @@ RSpec.describe "persistence" do
         it "works" do
           employee = PORO::Employee.create(first_name: "Jane")
           klass.find(id: employee.id).destroy
-          expect(klass.meta).to eq(method: :destroy)
+          expect(klass.meta).to include(method: :destroy)
         end
       end
 
@@ -1598,6 +1598,7 @@ RSpec.describe "persistence" do
             method: :destroy,
             attributes: {employee_id: nil, id: 1},
             relationships: {},
+            scope: nil,
             temp_id: nil
           })
           expect(position_resource.meta[:caller_model]).to be_a(PORO::Employee)
@@ -1618,7 +1619,7 @@ RSpec.describe "persistence" do
         it "works" do
           employee = PORO::Employee.create(first_name: "Jane")
           klass.find(id: employee.id).destroy
-          expect(klass.meta).to eq(method: :destroy)
+          expect(klass.meta).to include(method: :destroy)
         end
       end
 
@@ -1636,7 +1637,7 @@ RSpec.describe "persistence" do
         it "works" do
           employee = PORO::Employee.create(first_name: "Jane")
           klass.find(id: employee.id).destroy
-          expect(klass.meta).to eq(method: :destroy)
+          expect(klass.meta).to include(method: :destroy)
         end
       end
     end
@@ -1656,7 +1657,7 @@ RSpec.describe "persistence" do
       it "works" do
         employee = PORO::Employee.create(first_name: "Jane")
         klass.find(id: employee.id).destroy
-        expect(klass.meta).to eq(method: :destroy)
+        expect(klass.meta).to include(method: :destroy)
       end
     end
 
@@ -1742,7 +1743,7 @@ RSpec.describe "persistence" do
       it "works" do
         employee = PORO::Employee.create(first_name: "Jane")
         klass.find(id: employee.id).destroy
-        expect(klass.meta).to eq(method: :destroy)
+        expect(klass.meta).to include(method: :destroy)
       end
     end
   end


### PR DESCRIPTION
When building new resources or updating/deleting existing resources, Graphiti will find the objects directly by ID, dropping any existing scopes. We cannot restrict these lookups using ActiveRecord scopes, nwhich removes a layer of defense for lookups and updates.

Instead, when a RecordProxy has a scope, we should use that scope to create or lookup records. If scope is undefined, it will fall back to base_scope, rather than using the record class directly.